### PR TITLE
Fix mac package script if the ./Packages directory doesn't exist

### DIFF
--- a/BuildMacOSPackages.sh
+++ b/BuildMacOSPackages.sh
@@ -21,7 +21,7 @@ echo "Version: $VERSION"
 # Create output directory
 if [[ ! -d "./Packages/$VERSION" ]]; then
     echo "Create directory 'Packages/$VERSION'"
-    mkdir ./Packages/$VERSION
+    mkdir -p ./Packages/$VERSION
     if [ "$?" != "0" ]; then
         exit
     fi


### PR DESCRIPTION
Without this change, the script errors out if the ./Packages folder doesn't exist already