### PR TITLE
Fix P010/P012/P016 rendering

### DIFF
--- a/PixelViewer/Media/ImageRenderers/BaseYuv420sp16ImageRenderer.cs
+++ b/PixelViewer/Media/ImageRenderers/BaseYuv420sp16ImageRenderer.cs
@@ -20,7 +20,7 @@ namespace Carina.PixelViewer.Media.ImageRenderers
 		/// Initialize new <see cref="BaseYuv420sp16ImageRenderer"/> instance.
 		/// </summary>
 		/// <param name="format">Supported format.</param>
-		/// <param name="effectiveBits">Effective bits for each Y/U/V coponent.</param>
+		/// <param name="effectiveBits">Effective bits for each Y/U/V component.</param>
 		public BaseYuv420sp16ImageRenderer(ImageFormat format, int effectiveBits) : base(format)
 		{
 			if (effectiveBits < 10 || effectiveBits > 16)

--- a/PixelViewer/Media/ImageRenderers/BaseYuv420sp16ImageRenderer.cs
+++ b/PixelViewer/Media/ImageRenderers/BaseYuv420sp16ImageRenderer.cs
@@ -162,15 +162,14 @@ namespace Carina.PixelViewer.Media.ImageRenderers
 
 
 	/// <summary>
-    /// <see cref="IImageRenderer"/> which supports rendering image with 10-bit YUV420p based format.
+    /// <see cref="IImageRenderer"/> which supports rendering image with 10-bit YUV420sp based format.
     /// </summary>
-    class P010ImageRenderer : BaseYuv420p16ImageRenderer
+    class P010ImageRenderer : BaseYuv420sp16ImageRenderer
     {
         public P010ImageRenderer() : base(new ImageFormat(ImageFormatCategory.YUV, "P010", true, new ImagePlaneDescriptor[] {
             new(2),
-            new(2),
-            new(2),
-        }, new[]{ "P010" }), 10)
+            new(4),
+        }, new[]{ "P010" }), 16)
         { }
 
 
@@ -184,15 +183,14 @@ namespace Carina.PixelViewer.Media.ImageRenderers
 
 
 	/// <summary>
-    /// <see cref="IImageRenderer"/> which supports rendering image with 12-bit YUV420p based format.
+    /// <see cref="IImageRenderer"/> which supports rendering image with 12-bit YUV420sp based format.
     /// </summary>
-    class P012ImageRenderer : BaseYuv420p16ImageRenderer
+    class P012ImageRenderer : BaseYuv420sp16ImageRenderer
     {
         public P012ImageRenderer() : base(new ImageFormat(ImageFormatCategory.YUV, "P012", true, new ImagePlaneDescriptor[] {
             new(2),
-            new(2),
-            new(2),
-        }, new[]{ "P012" }), 12)
+            new(4),
+        }, new[]{ "P012" }), 16)
         { }
 
 
@@ -208,12 +206,11 @@ namespace Carina.PixelViewer.Media.ImageRenderers
 	/// <summary>
     /// <see cref="IImageRenderer"/> which supports rendering image with 16-bit YUV420p based format.
     /// </summary>
-    class P016ImageRenderer : BaseYuv420p16ImageRenderer
+    class P016ImageRenderer : BaseYuv420sp16ImageRenderer
     {
         public P016ImageRenderer() : base(new ImageFormat(ImageFormatCategory.YUV, "P016", true, new ImagePlaneDescriptor[] {
             new(2),
-            new(2),
-            new(2),
+            new(4),
         }, new[]{ "P016" }), 16)
         { }
 


### PR DESCRIPTION
I was trying to view a P010 raw file and noticed that no real settings combinations worked in displaying something recognizable, so I went in and made some changes that made them display properly:

- Switch the inherited class for the derived ImageRenderer classes for these
image types to `BaseYuv420sp16ImageRenderer` from
`BaseYuv420p16ImageRenderer`; it looks like this was was the intended
class to inherit from due to these classes being defined in the
BaseYuv420sp16ImageRenderer source file.

- As well, change the constructor for these to only initialize two planes
instead of three since the P01* image types are semi-planar formats,
similar to NV12.

- Finally, change the effective bits for all of these types to 16 bits;
the idea behind the format is that for P010 and P012 the unused lower bits are
0 and so they can be interpreted as less-detailed versions of P016.

With these, I can open a P010 file and it looks like how the originating image should. I haven't tested this with a P012 or P016 file, but I think they need the same changes as the ones I made for P010 (except for the 16 effective bits for P016).